### PR TITLE
Add GIT support

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -38,6 +38,24 @@
           "path": "org.qownnotes.QOwnNotes.appdata.xml"
         }
       ]
+    },
+    {
+      "name": "git",
+      "make-args": [
+        "NO_TCLTK=YesPlease",
+        "NO_INSTALL_HARDLINKS=YesPlease"
+      ],
+      "make-install-args": [
+        "NO_TCLTK=YesPlease",
+        "NO_INSTALL_HARDLINKS=YesPlease"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.kernel.org/pub/software/scm/git/git-2.19.1.tar.xz",
+          "sha256": "345056aa9b8084280b1b9fe1374d232dec05a34e8849028a20bfdb56e920dbb5"
+        }
+      ]
     }
   ]
 }

--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -52,8 +52,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://www.kernel.org/pub/software/scm/git/git-2.19.1.tar.xz",
-          "sha256": "345056aa9b8084280b1b9fe1374d232dec05a34e8849028a20bfdb56e920dbb5"
+          "url": "https://www.kernel.org/pub/software/scm/git/git-2.19.2.tar.xz",
+          "sha256": "fce9a3a3297db5f3756c4553a2fc1fec209ee08178f8491e76ff4ff8fe7b8be9"
         }
       ]
     }


### PR DESCRIPTION
QOwnNotes has initial support for git used for versioning local notes.