### PR TITLE
Update runtime/sdk to 5.12

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.qownnotes.QOwnNotes",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.11",
+  "runtime-version": "5.12",
   "sdk": "org.kde.Sdk",
   "command": "QOwnNotes",
   "rename-desktop-file": "PBE.QOwnNotes.desktop",


### PR DESCRIPTION
Built and tested locally. Appears to work fine when tested with my notes.

The only thing I noticed were the main top panel icons, which are now scaled to crazy large proportions on my 4k display. Although this is hardly the the first time I have had strange scaling problems with Qt apps, with Flatpak or otherwise. The app itself works fine.

This is a LTS version of Qt, by the way, in case it matters to you.