### PR TITLE
Move to 5.15-21.08 runtime

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.qownnotes.QOwnNotes",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "QOwnNotes",
   "rename-desktop-file": "PBE.QOwnNotes.desktop",


### PR DESCRIPTION
This is new kde 5.15 runtime build on top of freedesktop 21.08 release which is what majority of kde apps use these days.