### PR TITLE
Use flathubbot to track updates

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -24,7 +24,13 @@
         {
           "type": "archive",
           "url": "https://download.tuxfamily.org/qownnotes/src/qownnotes-21.11.10.tar.xz",
-          "sha256": "70c231e9bf045b36e695915722da673a7baf03c1a17b704a3a4b050dfc6548cb"
+          "sha256": "70c231e9bf045b36e695915722da673a7baf03c1a17b704a3a4b050dfc6548cb",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://download.tuxfamily.org/qownnotes/src/",
+                        "pattern": "(qownnotes-([\\d\\.]+).tar.xz)",
+                        "is-main-source": true
+                    }
         }
       ]
     },


### PR DESCRIPTION
After this is merged flathubbot will automatically track new releases hosted on tuxfamiy and open PR when new version is found (hashes, appdata will be updated automatically too). You still would need to merge the PR (after it successfully builds). It's possible to auto-merge successful PR too which could be the next step.

Note that the updated PR will change formatting of manifest (it uses 4 spaces) so the initial diff will be huge but next ones will be normal.

Fixes https://github.com/flathub/org.qownnotes.QOwnNotes/issues/49