### PR TITLE
Fix linter issues

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -8,13 +8,13 @@
     "rename-icon": "QOwnNotes",
     "finish-args": [
         "--socket=wayland",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--share=ipc",
         "--share=network",
         "--filesystem=home",
         "--device=dri",
         "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.StatusNotifierItem-3-1"
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
* Use fallback-x11 to not expose x11 socket when wayland display server is used.

* Own whole org.kde.* dbus domain since specific numbers can conflict among other apps