### PR TITLE
Add x-checker for git

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -60,7 +60,13 @@
                 {
                     "type": "archive",
                     "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.33.1.tar.xz",
-                    "sha256": "e054a6e6c2b088bd1bff5f61ed9ba5aa91c9a3cd509539a4b41c5ddf02201f2f"
+                    "sha256": "e054a6e6c2b088bd1bff5f61ed9ba5aa91c9a3cd509539a4b41c5ddf02201f2f",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 5350,
+                        "stable-only": true,
+                        "url-template": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$version.tar.xz"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
git receives some security updates every odd release or so. So let's make sure it stays updated automatically. x-checker will open PRs whenever there's an update.