### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.qownnotes.QOwnNotes.json
+++ b/org.qownnotes.QOwnNotes.json
@@ -13,8 +13,7 @@
         "--share=network",
         "--filesystem=home",
         "--device=dri",
-        "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.*"
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
         {


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025